### PR TITLE
Added ./, includes/ and tests/ to INCLUDES

### DIFF
--- a/Firmware/build/Makefile
+++ b/Firmware/build/Makefile
@@ -39,7 +39,7 @@ HEADERS = $(wildcard ../*.h) $(wildcard ../includes/*.h)
 
 # include directories (used for both, c and asm)
 # eg '. usbdrv/'
-INCLUDES =
+INCLUDES = ../ . ../includes/ ../tests/
 
 
 # use more debug-flags when compiling


### PR DESCRIPTION
now every .h file in this directories can be included without the path.
e.g.: include "../includes/adc.h" can be included by include "adc.h"
everywhere in the project