### PR TITLE
fixed includes in uart.h

### DIFF
--- a/Firmware/includes/uart.h
+++ b/Firmware/includes/uart.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <stdio.h>
 #include <avr/pgmspace.h>
 //----------------------------------------//
 typedef enum{


### PR DESCRIPTION
In the former version stdio.h had to be include before uart.h in every
file using uart.h.
Now it is only necessary to include uart.h