### PR TITLE
Watchdog and display cleanup

### DIFF
--- a/Firmware/includes/display.c
+++ b/Firmware/includes/display.c
@@ -5,7 +5,7 @@
 #include "timing.h"
 
 
-#define DISPLAY_REFRESH_INTERVAL 1 // 0.5ms 
+#define DISPLAY_REFRESH_INTERVAL 60 // 0.5ms 
 
 static uint16_t i2bcd(uint16_t i);
 static void display_custom(uint8_t led_idx, uint8_t segments);

--- a/Firmware/includes/display.c
+++ b/Firmware/includes/display.c
@@ -5,52 +5,11 @@
 #include "timing.h"
 
 
-#define DISPLAY_REFRESH_INTERVAL 60 // 0.5ms 
+#define DISPLAY_REFRESH_INTERVAL 1 // 0.5ms 
 
 static uint16_t i2bcd(uint16_t i);
 static void display_custom(uint8_t led_idx, uint8_t segments);
 
-typedef enum {
-	SIGN_0=(DISP_BOT|DISP_UL|DISP_UR|DISP_UP|DISP_BL|DISP_BR),
-	SIGN_1=(DISP_BR|DISP_UR),
-	SIGN_2=(DISP_UP|DISP_UR|DISP_MID|DISP_BL|DISP_BOT),
-	SIGN_3=(DISP_UP|DISP_UR|DISP_MID|DISP_BR|DISP_BOT),
-	SIGN_4=(DISP_UL|DISP_MID|DISP_UR|DISP_BR) ,
-	SIGN_5=(DISP_UP|DISP_UL|DISP_MID|DISP_BR|DISP_BOT),
-	SIGN_6=(DISP_UP|DISP_UL|DISP_MID|DISP_BL|DISP_BOT|DISP_BR),
-	SIGN_7=(DISP_UP|DISP_UR|DISP_BR) ,
-	SIGN_8=(DISP_UP|DISP_UR|DISP_BR|DISP_UL|DISP_BL|DISP_MID|DISP_BOT),
-	SIGN_9=(DISP_UP|DISP_UR|DISP_BR|DISP_UL|DISP_MID|DISP_BOT),
-	SIGN_A=(DISP_UP|DISP_UR|DISP_BR|DISP_UL|DISP_BL|DISP_MID),
-	SIGN_B=(DISP_BR|DISP_UL|DISP_MID|DISP_BL|DISP_BOT),
-	SIGN_C=(DISP_UP|DISP_UL|DISP_BL|DISP_BOT),
-	SIGN_D=(DISP_UR|DISP_BR|DISP_BL|DISP_MID|DISP_BOT),
-	SIGN_E=(DISP_UP|DISP_UL|DISP_BL|DISP_MID|DISP_BOT),
-	SIGN_F=(DISP_UP|DISP_UL|DISP_BL|DISP_MID),
-	SIGN_G=(DISP_UP|DISP_UL|DISP_BL|DISP_BOT|DISP_BR),
-	SIGN_H=(DISP_UL|DISP_BL|DISP_MID|DISP_UR|DISP_BR),
-	SIGN_I=(DISP_UL|DISP_BL),
-	SIGN_J=(DISP_BOT|DISP_UR|DISP_UP|DISP_BL|DISP_BR),
-	SIGN_K=0, // not possible with this display
-	SIGN_L=(DISP_UL|DISP_BL|DISP_BOT),
-	SIGN_M=0, // not possible with this display
-	SIGN_N=(DISP_BL|DISP_MID|DISP_BR),
-	SIGN_O=(DISP_BL|DISP_MID|DISP_BR|DISP_BOT),
-	SIGN_P=(DISP_BL|DISP_UP|DISP_UL|DISP_MID|DISP_UR),
-	SIGN_Q=0, // not possible with this display
-	SIGN_R=(DISP_BL|DISP_MID),
-	SIGN_S=SIGN_5,
-	SIGN_T=(DISP_BL|DISP_BOT|DISP_MID|DISP_UL),
-	SIGN_U=(DISP_BOT|DISP_UL|DISP_UR|DISP_BL|DISP_BR),
-	SIGN_V=0, // not possible with this display
-	SIGN_W=0, // not possible with this display
-	SIGN_X=0, // not possible with this display
-	SIGN_Y=(DISP_UR|DISP_BR|DISP_UL|DISP_MID|DISP_BOT),
-	SIGN_Z=0, // not possible with this display
-	SIGN_DOT=(DISP_DOT),
-	SIGN_MINUS=(DISP_MID),
-	SIGN_NONE=0
-} sign_t;
 
 static uint8_t framebuffer[3];
 //extern uint16_t g_temperature;
@@ -88,6 +47,10 @@ void display_error() {
 	framebuffer[2] = SIGN_E;
 	framebuffer[1] = SIGN_R;
 	framebuffer[0] = SIGN_R;
+}
+
+void display_sign(uint8_t led_idx, sign_t sign){
+	framebuffer[led_idx] = sign;
 }
 
 

--- a/Firmware/includes/display.h
+++ b/Firmware/includes/display.h
@@ -9,12 +9,56 @@
 #pragma once
 
 #include <stdint.h>
+#include <avr/io.h>
 #include "pinout.h"
 
+
+typedef enum {
+	SIGN_0=(DISP_BOT|DISP_UL|DISP_UR|DISP_UP|DISP_BL|DISP_BR),
+	SIGN_1=(DISP_BR|DISP_UR),
+	SIGN_2=(DISP_UP|DISP_UR|DISP_MID|DISP_BL|DISP_BOT),
+	SIGN_3=(DISP_UP|DISP_UR|DISP_MID|DISP_BR|DISP_BOT),
+	SIGN_4=(DISP_UL|DISP_MID|DISP_UR|DISP_BR) ,
+	SIGN_5=(DISP_UP|DISP_UL|DISP_MID|DISP_BR|DISP_BOT),
+	SIGN_6=(DISP_UP|DISP_UL|DISP_MID|DISP_BL|DISP_BOT|DISP_BR),
+	SIGN_7=(DISP_UP|DISP_UR|DISP_BR) ,
+	SIGN_8=(DISP_UP|DISP_UR|DISP_BR|DISP_UL|DISP_BL|DISP_MID|DISP_BOT),
+	SIGN_9=(DISP_UP|DISP_UR|DISP_BR|DISP_UL|DISP_MID|DISP_BOT),
+	SIGN_A=(DISP_UP|DISP_UR|DISP_BR|DISP_UL|DISP_BL|DISP_MID),
+	SIGN_B=(DISP_BR|DISP_UL|DISP_MID|DISP_BL|DISP_BOT),
+	SIGN_C=(DISP_UP|DISP_UL|DISP_BL|DISP_BOT),
+	SIGN_D=(DISP_UR|DISP_BR|DISP_BL|DISP_MID|DISP_BOT),
+	SIGN_E=(DISP_UP|DISP_UL|DISP_BL|DISP_MID|DISP_BOT),
+	SIGN_F=(DISP_UP|DISP_UL|DISP_BL|DISP_MID),
+  SIGN_G=(DISP_UP|DISP_UL|DISP_BL|DISP_BOT|DISP_BR),
+  SIGN_H=(DISP_UL|DISP_BL|DISP_MID|DISP_UR|DISP_BR),
+  SIGN_I=(DISP_UL|DISP_BL),
+  SIGN_J=(DISP_BOT|DISP_UR|DISP_UP|DISP_BL|DISP_BR),
+  SIGN_K=0, // not possible with this display
+  SIGN_L=(DISP_UL|DISP_BL|DISP_BOT),
+  SIGN_M=0, // not possible with this display
+  SIGN_N=(DISP_BL|DISP_MID|DISP_BR),
+  SIGN_O=(DISP_BL|DISP_MID|DISP_BR|DISP_BOT),
+  SIGN_P=(DISP_BL|DISP_UP|DISP_UL|DISP_MID|DISP_UR),
+  SIGN_Q=0, // not possible with this display
+  SIGN_R=(DISP_BL|DISP_MID),
+  SIGN_S=SIGN_5,
+  SIGN_T=(DISP_BL|DISP_BOT|DISP_MID|DISP_UL),
+  SIGN_U=(DISP_BOT|DISP_UL|DISP_UR|DISP_BL|DISP_BR),
+  SIGN_V=0, // not possible with this display
+  SIGN_W=0, // not possible with this display
+  SIGN_X=0, // not possible with this display
+  SIGN_Y=(DISP_UR|DISP_BR|DISP_UL|DISP_MID|DISP_BOT),
+  SIGN_Z=0, // not possible with this display
+	SIGN_DOT=(DISP_DOT),
+	SIGN_MINUS=(DISP_MID),
+	SIGN_NONE=0
+} sign_t;
 
 void display_init();
 void display_update();
 void display_digit(uint8_t led_idx, uint8_t digit);
+void display_sign(uint8_t led_idx, sign_t sign);
 void display_temperature(int16_t number);
 void display_number(int16_t number);
 void display_fixed_point(int16_t number, int8_t exp);

--- a/Firmware/solder_iron.c
+++ b/Firmware/solder_iron.c
@@ -6,33 +6,96 @@
  */ 
 
 #include <util/delay.h>
-//#include "includes/uart.h"
 #include <avr/eeprom.h>
-#include "includes/display.h"
-#include "includes/adc.h"
-#include "includes/temperature.h"
+#include <avr/wdt.h>
 #include <avr/io.h>
+#include <avr/interrupt.h>
+
 #include "config.h"
+#include "eeprom-config.h"
+#include "display.h"
+#include "adc.h"
+#include "temperature.h"
+#include "uart.h"
 
 
-uint16_t last_temperature EEMEM = 350; //default
-int8_t temperature_offset EEMEM = -52; //default
+void on_watchdog_reset(void);
+/******************VERY IMPORTANT********************************************
+ * this code block is necessary to prevent the processor to run into watchdog-reset-lifelock 
+ * do NOT delete this block
+****************************************************************************/
+void wdt_init(void) __attribute__((naked)) __attribute__((section(".init3")));
 
+void wdt_init(void)
+{
+	wdt_reset();
+	wdt_enable(WDTO_8S);
+    return;
+}
+/*******************end of very important block***************************/
 
 int main(void)
 {
+	wdt_disable();
+	on_watchdog_reset();
+	wdt_enable(WDTO_500MS);
+	config_load();
 	display_init();
+	clock_init();
+	//control_init();  //leave this as a comment until we want to heat things up
 
-	//display_digit(1,3);
 
-	_delay_ms(100);
 
+	display_number(100);
 	while(1)
 	{
-		uint16_t value = measure_get_internal_temperature();
-		//uint16_t value = measure_get_internal_temperature();
-		display_temperature(value);
-		display_update();
-		_delay_us(200);
+		
+		wdt_reset(); //still alive
 	}
 }
+
+
+/*******************************************
+This function holds the soldering station
+from heating and forces the user to power 
+cycle it
+*******************************************/
+void on_watchdog_reset(void)
+{
+	if(MCUSR & (1 << WDRF)){ //stay in ERROR-mode when reseted by watchdog until power cycle
+		wdt_enable(WDTO_8S);
+		MCUSR &= ~(1 << WDRF);
+		DDRD |= (1 << PD4);
+		PORTD &= ~(1 << PD4); //make sure tip is off
+		config_load();
+		display_init();
+		clock_init();
+		uart_init(19200, one_stop_bit_e, no_parity_e);
+		sei();
+		while(1){ // give a hint that a power cycle is necessary
+			wdt_reset();
+			printf("ERROR: please power cycle this device\r\n");
+			display_sign(2,SIGN_E);
+			display_sign(1,SIGN_R);
+			display_sign(0,SIGN_R);
+			_delay_ms(700);
+			display_sign(2,SIGN_T);
+			display_sign(1,SIGN_R);
+			display_sign(0,SIGN_N); 
+			_delay_ms(700);
+			display_sign(2,SIGN_O);
+			display_sign(1,SIGN_F);
+			display_sign(0,SIGN_F); 
+			_delay_ms(700);
+			display_sign(2,SIGN_A);
+			display_sign(1,SIGN_N);
+			display_sign(0,SIGN_D); 
+			_delay_ms(700);
+			display_sign(2,0);
+			display_sign(1,SIGN_O);
+			display_sign(0,SIGN_N); 
+			_delay_ms(700);
+		}
+	}
+}
+


### PR DESCRIPTION
Closes #16 by activating the watchdog

After the AVR was reseted by the watchdog the tip is not heated again
until the device was power cycled. Until then an error is displayed.