### PR TITLE
New driver for rotary encoder to replace buttons

### DIFF
--- a/Firmware/config.h
+++ b/Firmware/config.h
@@ -3,6 +3,9 @@
 // #define HW_VERSION 1
 #define HW_VERSION 12 // current hardware version
 
+// Uncomment to use rotary encoder instead of button for temperature setting
+//#define ROTARY_ENCODER 1
+
 // the temperature the system is supposed to not exceed
 #define TEMP_MAX 380
 

--- a/Firmware/includes/pinout.h
+++ b/Firmware/includes/pinout.h
@@ -64,6 +64,23 @@
 	#define PWR0_PORT PORTD
 	#define PWR0      PD5
 
+	#ifdef ROTARY_ENCODER
+		#define ROTARY_A_PIN     PINC
+		#define ROTARY_B_PIN     PINC
+		#define ROTARY_BUTTON_PIN		PINC
+		
+		#define ROTARY_A_PIN_NR     PC2
+		#define ROTARY_B_PIN_NR     PC3
+		#define ROTARY_BUTTON_PIN_NR	PC4
+		
+		#define ROTARY_A_PORT     PORTC
+		#define ROTARY_B_PORT     PORTC
+		#define ROTARY_BUTTON_PORT		PORTC
+		
+		#define ROTARY_A_DDR     DDRC
+		#define ROTARY_B_DDR     DDRC
+		#define ROTARY_BUTTON_DDR		DDRC
+	#endif
 	
 //	#define BUTTON_UP (1<<PD2) // INT0
 //	#define BUTTON_DN (1<<PD3) // INT1

--- a/Firmware/includes/rotary_encoder.c
+++ b/Firmware/includes/rotary_encoder.c
@@ -1,0 +1,131 @@
+/*
+* @file: rotary_encoder.c
+*
+* Reads rotary encoder every 2ms and calls plus/minus/button-callbacks
+*
+* Author: Keno Garlichs, <k.garlichs@tu-braunschweig.de>              
+*/
+#include "rotary_encoder.h"
+
+// Encoder was rotated clockwise
+void (*plus_callback)(void);
+// Encoder was rotated counter clockwise
+void (*minus_callback)(void);
+// Buttons was pressed
+void (*third_callback)(void);
+// Buttons was held
+void (*third_long_callback)(void);
+
+uint8_t state, prevstate = 0;
+uint8_t nextEncoderState[4] = {2, 0, 3, 1};
+uint8_t prevEncoderState[4] = {1, 3, 0, 2};
+
+next_time_t rotary_check_timer; 
+
+/*
+ * @brief	Initializes required port pins,
+ * 			sets the poll timer and assigns
+ * 			callback functions for the different events
+ *
+ * @param	*p_callback		Pointer to the function to be called upon CW rotation
+ * @param	*m_callback		Pointer to the function to be called upon CCW rotation
+ * @param	*t_callback		Pointer to the function to be called upon short button press
+ * @param	*tl_callback	Pointer to the function to be called upon long button press
+ *
+ * @return void
+ */
+void encode_init(void (*p_callback)(void), void (*m_callback)(void), void (*t_callback)(void), void (*tl_callback)(void))
+{
+	// Configure pins as inputs
+	ROTARY_A_DDR &= ~(1 << ROTARY_A_PIN_NR);
+	ROTARY_B_DDR &= ~(1 << ROTARY_B_PIN_NR);
+	ROTARY_BUTTON_DDR &= ~(1 << ROTARY_BUTTON_PIN_NR);
+
+	// Enable internal pullups
+	ROTARY_A_PORT |= (1 << ROTARY_A_PIN_NR);
+	ROTARY_B_PORT |= (1 << ROTARY_B_PIN_NR);
+	ROTARY_BUTTON_PORT |= (1 << ROTARY_BUTTON_PIN_NR);
+   	
+	// Initialize poll timer
+   	timer_init(&rotary_check_timer, 0, 0, 1); 	// ~2ms
+   	timer_prepare();
+   	timer_set(&rotary_check_timer);
+
+	// Set up functions to be called upon respective actions
+	plus_callback = p_callback;
+	minus_callback = m_callback;
+	third_callback = t_callback;
+	third_long_callback = tl_callback;
+}
+
+/*
+ * @brief	Gets called by timer every x ms, evaluates
+ * rotary encoder and it's button. Then calls repective
+ * callback functions, defined during initialization
+ *
+ * @param void
+ * @return void
+ */
+void rotary_callback(void) {
+	static uint8_t skip_count = 0;
+	static uint16_t long_press_count = 0;
+
+	state = ROTARY_A_STATE | ROTARY_B_STATE;
+	if((state != prevstate) ) {
+		/* The rotary encoder we use gives four pulses per step
+		 * so we only count every fourth step */
+		if(skip_count++ == 3) {			
+			if (state == nextEncoderState[prevstate]) {
+				if(minus_callback != NULL) {
+					minus_callback();
+				}
+			}
+			else if (state == prevEncoderState[prevstate]) {
+				if(plus_callback != NULL) {
+					plus_callback();
+				}
+			}
+			skip_count = 0;
+		}
+
+		prevstate = state;
+  	}
+
+	// Now check the button
+	if(ROTARY_BUTTON_PRESSED) {
+		// Button is pressed at the moment
+		long_press_count++;
+	}
+	else {
+		/* Button was released, now check if it was pressed in the last cycle
+		 * and if yes, call functions with respect to to time it was held */
+		if((long_press_count < 250) && (long_press_count > 0)) {
+			// Button was pressed for less than a second
+			if(third_callback != NULL) {
+				third_callback();
+			}	
+		}
+		else if((long_press_count >= 250) && (long_press_count > 0)) {
+			// Button was pressed for more than a second
+			if(third_long_callback != NULL) {
+				third_long_callback();
+			}
+		}
+		long_press_count = 0;
+	}
+}
+
+/*
+ * @brief Gets called by main() every loop cycle
+ * 		  Checks, whether timer has expired. If yes, it calls
+ * 		  rotary_callback and restarts the timer
+ *
+ * @param void
+ * @return void
+ */
+void check_rotary_timer(void) {
+	if(timer_past(&rotary_check_timer)) {
+		timer_set(&rotary_check_timer);
+		rotary_callback();
+	}
+}

--- a/Firmware/includes/rotary_encoder.h
+++ b/Firmware/includes/rotary_encoder.h
@@ -1,0 +1,44 @@
+/*
+* @file: rotary_encoder.h
+*
+* Reads rotary encoder every 2ms and calls plus/minus/button-callbacks
+*
+* Author: Keno Garlichs, <k.garlichs@tu-braunschweig.de>              
+*/
+#include <avr/io.h>
+#include <avr/interrupt.h>
+#include <stdio.h>
+#include "timing.h"
+
+// Configure pins here
+#define ROTARY_A_PIN     PINC
+#define ROTARY_B_PIN     PINC
+#define ROTARY_BUTTON_PIN		PINC
+
+#define ROTARY_A_PIN_NR     PC2
+#define ROTARY_B_PIN_NR     PC3
+#define ROTARY_BUTTON_PIN_NR	PC4
+
+#define ROTARY_A_PORT     PORTC
+#define ROTARY_B_PORT     PORTC
+#define ROTARY_BUTTON_PORT		PORTC
+
+#define ROTARY_A_DDR     DDRC
+#define ROTARY_B_DDR     DDRC
+#define ROTARY_BUTTON_DDR		DDRC
+
+#define ROTARY_A     (ROTARY_A_PIN & (1 << ROTARY_A_PIN_NR))
+#define ROTARY_B     (ROTARY_B_PIN & (1 << ROTARY_B_PIN_NR))
+#define ROTARY_BUTTON_PRESSED		!(ROTARY_BUTTON_PIN & (1 << ROTARY_BUTTON_PIN_NR))
+
+#define ROTARY_A_STATE		(ROTARY_A >> 1)		// Shifts ROTARY_A bit to bit 1
+#define ROTARY_B_STATE		(ROTARY_B >> 3)		// Shifts ROTARY_B bit to bit 0
+
+extern void (*plus_callback)(void);
+extern void (*minus_callback)(void);
+extern void (*third_callback)(void);
+extern void (*third_long_callback)(void);
+
+void rotary_callback(void);
+void encode_init(void (*p_callback)(void), void (*m_callback)(void), void (*t_callback)(void), void (*tl_callback)(void));
+void check_rotary_timer(void);

--- a/Firmware/includes/rotary_encoder.h
+++ b/Firmware/includes/rotary_encoder.h
@@ -5,34 +5,18 @@
 *
 * Author: Keno Garlichs, <k.garlichs@tu-braunschweig.de>              
 */
+#pragma once
+
 #include <avr/io.h>
-#include <avr/interrupt.h>
 #include <stdio.h>
 #include "timing.h"
-
-// Configure pins here
-#define ROTARY_A_PIN     PINC
-#define ROTARY_B_PIN     PINC
-#define ROTARY_BUTTON_PIN		PINC
-
-#define ROTARY_A_PIN_NR     PC2
-#define ROTARY_B_PIN_NR     PC3
-#define ROTARY_BUTTON_PIN_NR	PC4
-
-#define ROTARY_A_PORT     PORTC
-#define ROTARY_B_PORT     PORTC
-#define ROTARY_BUTTON_PORT		PORTC
-
-#define ROTARY_A_DDR     DDRC
-#define ROTARY_B_DDR     DDRC
-#define ROTARY_BUTTON_DDR		DDRC
 
 #define ROTARY_A     (ROTARY_A_PIN & (1 << ROTARY_A_PIN_NR))
 #define ROTARY_B     (ROTARY_B_PIN & (1 << ROTARY_B_PIN_NR))
 #define ROTARY_BUTTON_PRESSED		!(ROTARY_BUTTON_PIN & (1 << ROTARY_BUTTON_PIN_NR))
 
-#define ROTARY_A_STATE		(ROTARY_A >> 1)		// Shifts ROTARY_A bit to bit 1
-#define ROTARY_B_STATE		(ROTARY_B >> 3)		// Shifts ROTARY_B bit to bit 0
+#define ROTARY_A_STATE		(ROTARY_A >> (ROTARY_A_PIN_NR - 1))		// Shifts ROTARY_A bit to bit 1
+#define ROTARY_B_STATE		(ROTARY_B >> ROTARY_B_PIN_NR)		// Shifts ROTARY_B bit to bit 0
 
 extern void (*plus_callback)(void);
 extern void (*minus_callback)(void);

--- a/Firmware/solder_iron.c
+++ b/Firmware/solder_iron.c
@@ -24,6 +24,7 @@
 #include "tip.h"
 #include "clock.h"
 #include "controller.h"
+#include "rotary_encoder.h"
 
 
 void on_watchdog_reset(void);
@@ -94,6 +95,9 @@ int main(void)
 	display_init();
 	clock_init();
 	buttons_init(&plus, &minus, &back_to_default, &goto_menu);
+#ifdef ROTARY_ENCODER
+	encode_init(&plus, &minus, &back_to_default, &goto_menu);
+#endif
 	uart_init(19200, one_stop_bit_e, no_parity_e);
 
 	next_time_t new_temp_timer;
@@ -137,6 +141,11 @@ int main(void)
 				}
 			}
 		}
+
+#ifdef ROTARY_ENCODER
+		check_rotary_timer();
+#endif
+
 		wdt_reset(); //still alive
 		
 	}

--- a/Firmware/solder_iron.c
+++ b/Firmware/solder_iron.c
@@ -24,7 +24,10 @@
 #include "tip.h"
 #include "clock.h"
 #include "controller.h"
-#include "rotary_encoder.h"
+
+#ifdef ROTARY_ENCODER
+	#include "rotary_encoder.h"
+#endif
 
 
 void on_watchdog_reset(void);
@@ -80,6 +83,9 @@ void goto_menu(void)
 void from_menu(void)
 {
 	buttons_init(&plus, &minus, &back_to_default, &goto_menu);
+#ifdef ROTARY_ENCODER
+	encode_init(&plus, &minus, &back_to_default, &goto_menu);
+#endif
 	control_set_temp(tip_setted_temp());
 
 }


### PR DESCRIPTION
Adds driver for rotary encoder which can be used to configure set temperature and navigate through menu, instead of the PCB mounted buttons. The three pins needed can be configured in the header file. By default, the two free pins PC2 and PC3, as well as the I2C SDA pin (PC4) are used. The driver can be enabled in config.h
